### PR TITLE
Update 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Static Badge](https://img.shields.io/badge/desktop-006874)
 ![Static Badge](https://img.shields.io/badge/wasmjs-834C74)
 
-**v1.0.4**
+**v1.0.5**
 
 KInfo allows to access the device details of `android`, `iOS`, `desktop` e `web` devices
 
@@ -17,7 +17,7 @@ KInfo allows to access the device details of `android`, `iOS`, `desktop` e `web`
 
 ```groovy
 dependencies {
-    implementation 'io.github.n7ghtm4r3:kinfo:1.0.4'
+    implementation 'io.github.n7ghtm4r3:kinfo:1.0.5'
 }
 ```
 
@@ -25,7 +25,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.n7ghtm4r3:kinfo:1.0.4")
+    implementation("io.github.n7ghtm4r3:kinfo:1.0.5")
 }
 ```
 
@@ -35,7 +35,7 @@ dependencies {
 
 ```toml
 [versions]
-kinfo = "1.0.4"
+kinfo = "1.0.5"
 
 [libraries]
 kinfo = { module = "io.github.n7ghtm4r3:kinfo", version.ref = "kinfo" }

--- a/docs/android/os_info.md
+++ b/docs/android/os_info.md
@@ -270,6 +270,22 @@ The version code for **Android 14**
 println(versionCode.UPSIDE_DOWN_CAKE) // 34
 ```
 
+#### VANILLA_ICE_CREAM
+
+The version code for **Android 15**
+
+```kotlin
+println(versionCode.VANILLA_ICE_CREAM) // 35
+```
+
+#### BAKLAVA
+
+The version code for **Android 16**
+
+```kotlin
+println(versionCode.BAKLAVA) // 36
+```
+
 ## androidId
 
 Unique Android ID of the device

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ KInfo allows to access the device details of `android`, `iOS`, `desktop` e `web`
 
 ```groovy
 dependencies {
-    implementation 'io.github.n7ghtm4r3:kinfo:1.0.4'
+    implementation 'io.github.n7ghtm4r3:kinfo:1.0.5'
 }
 ```
 
@@ -16,7 +16,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.n7ghtm4r3:kinfo:1.0.4")
+    implementation("io.github.n7ghtm4r3:kinfo:1.0.5")
 }
 ```
 
@@ -26,7 +26,7 @@ dependencies {
 
 ```toml
 [versions]
-kinfo = "1.0.4"
+kinfo = "1.0.5"
 
 [libraries]
 kinfo = { module = "io.github.n7ghtm4r3:kinfo", version.ref = "kinfo" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 androidGradlePlugin = "8.12.3"
-kotlin = "2.2.20"
+kotlin = "2.2.21"
 android-minSdk = "24"
 android-compileSdk = "36"
-jetbrainsCompose = "1.9.0"
+jetbrainsCompose = "1.9.3"
 dokka = "2.0.0"
 annotation = "1.9.1"
-oshi = "6.9.0"
+oshi = "6.9.1"
 startupRuntime = "1.2.0"
 androidXCore = "1.17.0"
-equinox = "1.1.6"
+equinox = "1.1.7"
 
 [libraries]
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "com.teknobit.kinfo"
-version = "1.0.4"
+version = "1.0.5"
 
 kotlin {
     jvm {
@@ -124,7 +124,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.n7ghtm4r3",
         artifactId = "kinfo",
-        version = "1.0.4"
+        version = "1.0.5"
     )
     pom {
         name.set("KInfo")

--- a/library/src/androidMain/kotlin/com/tecknobit/kinfo/model/AndroidVersionCodeImpl.kt
+++ b/library/src/androidMain/kotlin/com/tecknobit/kinfo/model/AndroidVersionCodeImpl.kt
@@ -98,5 +98,19 @@ internal class AndroidVersionCodeImpl : VersionCode {
      * `UPSIDE_DOWN_CAKE` the version code for Android 14 (API level 34)
      */
     override val UPSIDE_DOWN_CAKE: Int = Build.VERSION_CODES.UPSIDE_DOWN_CAKE
-    
+
+    /**
+     * `VANILLA_ICE_CREAM` the version code for Android 15 (API level 35)
+     *
+     * @since 1.0.5
+     */
+    override val VANILLA_ICE_CREAM: Int = Build.VERSION_CODES.VANILLA_ICE_CREAM
+
+    /**
+     * `BAKLAVA` the version code for Android 16 (API level 36)
+     *
+     * @since 1.0.5
+     */
+    override val BAKLAVA: Int = Build.VERSION_CODES.VANILLA_ICE_CREAM
+
 }

--- a/library/src/androidMain/kotlin/com/tecknobit/kinfo/model/AndroidVersionImpl.kt
+++ b/library/src/androidMain/kotlin/com/tecknobit/kinfo/model/AndroidVersionImpl.kt
@@ -22,10 +22,9 @@ internal class AndroidVersionImpl : Version {
     /**
      * `baseOs` returns the base operating system version of the Android device
      *
-     * @throws [ApiLevelException] if the API level is below Marshmallow (API 23)
+     * @throws `ApiLevelException` if the API level is below Marshmallow (API 23)
      */
     override val baseOs: String
-        @RequiresApi(Build.VERSION_CODES.M)
         get() = Build.VERSION.BASE_OS
 
     /**
@@ -55,7 +54,7 @@ internal class AndroidVersionImpl : Version {
     /**
      * `releaseOrCodeName` returns either the release version or the code name of the Android version
      *
-     * @throws [ApiLevelException] if the API level is below Android 12 (API 31)
+     * @throws `ApiLevelException` if the API level is below Android 12 (API 31)
      */
     override val releaseOrCodeName: String
         @RequiresApi(Build.VERSION_CODES.R)
@@ -64,7 +63,7 @@ internal class AndroidVersionImpl : Version {
     /**
      * `releaseOrPreviewDisplay` returns either the release version or the preview display name if the device is in preview mode
      *
-     * @throws [ApiLevelException] if the API level is below Android 14 (API 34)
+     * @throws `ApiLevelException` if the API level is below Android 14 (API 34)
      */
     override val releaseOrPreviewDisplay: String
         @RequiresApi(Build.VERSION_CODES.TIRAMISU)
@@ -73,16 +72,15 @@ internal class AndroidVersionImpl : Version {
     /**
      * `securityPatch` returns the security patch level of the current Android version
      *
-     * @throws [ApiLevelException] if the API level is below Marshmallow (API 23)
+     * @throws `ApiLevelException` if the API level is below Marshmallow (API 23)
      */
     override val securityPatch: String
-        @RequiresApi(Build.VERSION_CODES.M)
         get() = Build.VERSION.SECURITY_PATCH
 
     /**
      * `mediaPerformanceClass` returns the media performance class of the Android device
      *
-     * @throws [ApiLevelException] if the API level is below Android 12 (API 31)
+     * @throws `ApiLevelException` if the API level is below Android 12 (API 31)
      */
     override val mediaPerformanceClass: Int
         @RequiresApi(Build.VERSION_CODES.S)
@@ -91,10 +89,9 @@ internal class AndroidVersionImpl : Version {
     /**
      * `previewSdkInt` returns the SDK version for preview releases of Android
      *
-     * @throws [ApiLevelException] if the API level is below Marshmallow (API 23)
+     * @throws `ApiLevelException` if the API level is below Marshmallow (API 23)
      */
     override val previewSdkInt: Int
-        @RequiresApi(Build.VERSION_CODES.M)
         get() = Build.VERSION.PREVIEW_SDK_INT
 
 }

--- a/library/src/commonMain/kotlin/com/tecknobit/kinfo/model/android/VersionCode.kt
+++ b/library/src/commonMain/kotlin/com/tecknobit/kinfo/model/android/VersionCode.kt
@@ -97,4 +97,18 @@ interface VersionCode {
      * `UPSIDE_DOWN_CAKE` the version code for Android 14 (API level 34)
      */
     val UPSIDE_DOWN_CAKE: Int
+
+    /**
+     * `VANILLA_ICE_CREAM` the version code for Android 15 (API level 35)
+     *
+     * @since 1.0.5
+     */
+    val VANILLA_ICE_CREAM: Int
+
+    /**
+     * `BAKLAVA` the version code for Android 16 (API level 36)
+     *
+     * @since 1.0.5
+     */
+    val BAKLAVA: Int
 }

--- a/library/src/jvmMain/kotlin/com/tecknobit/kinfo/model/hardware/HardwareImpl.kt
+++ b/library/src/jvmMain/kotlin/com/tecknobit/kinfo/model/hardware/HardwareImpl.kt
@@ -205,7 +205,7 @@ class HardwareImpl(
                     size = disk.size,
                     reads = disk.reads,
                     readBytes = disk.readBytes,
-                    writes = disk.readBytes,
+                    writes = disk.writes,
                     writesBytes = disk.writeBytes,
                     currentQueueLength = disk.currentQueueLength,
                     transferTime = disk.transferTime,


### PR DESCRIPTION
## Android

- Added the `VersionCode.VANILLA_ICE_CREAM` constant
- Added the `VersionCode.BAKLAVA` constant

## Deskop

- Bumped [oshi](https://github.com/oshi/oshi/releases/tag/oshi-parent-6.9.1) to the latest version (`6.9.1`)
- Fixed `HardwareInfo.diskStores` initialization due wrongly initialization of the `writes` property